### PR TITLE
Ruby 3.2 compatibility

### DIFF
--- a/factory_bot_instruments.gemspec
+++ b/factory_bot_instruments.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 2.4"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "sqlite3"
 end

--- a/factory_bot_instruments.gemspec
+++ b/factory_bot_instruments.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "factory_bot", "~> 4.5"
   spec.add_dependency "activerecord", ">= 4.0"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "sqlite3"

--- a/lib/factory_bot_instruments.rb
+++ b/lib/factory_bot_instruments.rb
@@ -14,7 +14,7 @@ module FactoryBotInstruments
   def self.benchmark_report(options = {})
     options = { :progress => true }.merge(options)
 
-    FactoryBot.benchmark_all(options).each do |benchmark|
+    FactoryBot.benchmark_all(**options).each do |benchmark|
       puts benchmark
     end
   end

--- a/spec/factory_bot_instruments_spec.rb
+++ b/spec/factory_bot_instruments_spec.rb
@@ -12,10 +12,12 @@ RSpec.describe FactoryBotInstruments do
     end
 
     it "prints the benchmark on STDOUT" do
-      output = IOHelper.capture { FactoryBotInstruments.benchmark_report }
+      output = IOHelper.capture do
+        FactoryBotInstruments.benchmark_report(progress: false)
+      end
 
       output.split("\n") do |line|
-        expect(line).to match(/\d+.\d+s\: Factory\..+\(\:.+\)/)
+        expect(line).to match(/\d+.\d+s\: FactoryBot\..+\(\:.+\)/)
       end
     end
   end


### PR DESCRIPTION
- Update Bundler and Rake to make them compatible with Ruby 3.2.
- Update code to make it compatible with Ruby 3.2.
- Fix a spec that failed on Ruby 3.2.