### PR TITLE
Migrate from Semaphore Classic -> Semaphore 2.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,16 @@
+version: v1.0
+name: Ruby
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2004
+blocks:
+  - name: bundle exec rspec
+    task:
+      jobs:
+        - name: rspec
+          commands:
+            - checkout
+            - sem-version ruby 3.2.0
+            - bundle install
+            - bundle exec rspec

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,5 +12,6 @@ blocks:
           commands:
             - checkout
             - sem-version ruby 3.2.0
+            - 'gem install bundler:1.17.3'
             - bundle install
             - bundle exec rspec


### PR DESCRIPTION
It is erroring out, but I assume that is because it is not compatible with the latest ruby/bundler versions.

<img width="958" alt="Screenshot 2023-09-19 at 17 47 38" src="https://github.com/shiroyasha/factory_bot_instruments/assets/1779493/5a18e869-8723-4bcd-9d7b-6308f41661f0">
