### PR TITLE
Factory bot dependency

### DIFF
--- a/factory_bot_instruments.gemspec
+++ b/factory_bot_instruments.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "factory_bot", "~> 4.5"
+  spec.add_dependency "factory_bot", ">= 4"
   spec.add_dependency "activerecord", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 2.4"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :article do
-    title "New Article"
-    content "article content"
+    title { "New Article" }
+    content { "article content" }
 
     user
   end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :comment do
-    content "First!"
+    content { "First!" }
 
     user
     article

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    name "Peter Parker"
-    username "spiderman"
+    name { "Peter Parker" }
+    username { "spiderman" }
   end
 end


### PR DESCRIPTION
Fix https://github.com/shiroyasha/factory_bot_instruments/issues/4.

A new version of the gem can be released after this one.